### PR TITLE
Add yamlfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ made up of composable, open-source-friendly tools.
 
 Each CI/CD run progresses through the following stages:
 
-1. **Lint** — markdownlint-cli2 · cspell · yamllint
+1. **Lint** — markdownlint-cli2 · cspell · yamllint · yamlfix
 2. **Build** — dotnet build/test + SonarScanner
 3. **Analyze** — CodeQL (produces SARIF output)
 4. **Validate** — Tool self-validation (produces TRX/JUnit output)
@@ -102,6 +102,7 @@ Each CI/CD run progresses through the following stages:
 | Linting | [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) | Markdown style and formatting |
 | Linting | [cspell](https://github.com/streetsidesoftware/cspell) | Spell-checking across all text files |
 | Linting | [yamllint](https://github.com/adrienverge/yamllint) | YAML structure and formatting |
+| Linting | [yamlfix](https://github.com/lyz-code/yamlfix) | YAML fixer |
 | Version Capture | [VersionMark](https://github.com/demaconsulting/VersionMark) | Records tool versions for each CI/CD job |
 | Static Analysis | [SonarMark](https://github.com/demaconsulting/SonarMark) | SonarQube/SonarCloud quality gate reporting |
 | Static Analysis | [SarifMark](https://github.com/demaconsulting/SarifMark) | CodeQL/SARIF analysis reporting |
@@ -173,7 +174,7 @@ practice. These templates are the recommended starting point for new projects:
 
 Detailed documentation for each part of the pipeline:
 
-- [Linting](docs/linting.md) — markdownlint-cli2, cspell, and yamllint configuration
+- [Linting](docs/linting.md) — markdownlint-cli2, cspell, yamllint, and yamlfix configuration
 - [Tool Version Capture](docs/tool-versions.md) — VersionMark setup and usage
 - [Static Analysis](docs/static-analysis.md) — SonarMark and SarifMark integration
 - [Requirements Enforcement](docs/requirements.md) — ReqStream YAML format and CI/CD integration

--- a/templates/lint/.cspell.yaml
+++ b/templates/lint/.cspell.yaml
@@ -22,6 +22,7 @@ words:
   - markdownlint
   - cspell
   - pandoc
+  - yamlfix
 
 # Exclude common build artifacts, dependencies, and vendored third-party code
 ignorePaths:

--- a/templates/lint/.yamlfix.toml
+++ b/templates/lint/.yamlfix.toml
@@ -1,0 +1,14 @@
+# YAML Auto-Fix Configuration
+#
+# PURPOSE:
+# - Configure yamlfix to auto-fix common YAML issues before yamllint checks
+# - Settings MUST align with .yamllint.yaml to avoid conflicts
+# - Run 'yamlfix .' before 'lint.bat' to auto-fix, then yamllint verifies
+#
+# RELATIONSHIP TO YAMLLINT:
+# - line_length MUST match .yamllint.yaml line-length.max (120)
+# - preserve_quotes prevents mangling GitHub Actions 'on:' boolean handling
+# - After yamlfix auto-fix, yamllint should only fail on genuinely unresolvable issues
+
+line_length = 120
+preserve_quotes = true

--- a/templates/lint/pip-requirements.txt
+++ b/templates/lint/pip-requirements.txt
@@ -1,1 +1,2 @@
 yamllint==1.38.0
+yamlfix==1.19.1


### PR DESCRIPTION
This pull request adds `yamlfix` as a YAML auto-fixing tool to the linting pipeline and updates related documentation and configuration files to support its use. The main goal is to auto-correct common YAML issues before running `yamllint`, ensuring consistency and reducing manual fixes.

**Linting improvements:**

* Added `yamlfix` to the linting stage in the CI/CD pipeline and updated documentation to reflect its inclusion and usage (`README.md`, `templates/lint/pip-requirements.txt`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-R91) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R105) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L176-R177) [[4]](diffhunk://#diff-c54b9345a14e81eb3593162927b058a04a763affd022c4b20e39e644c546019dR2)
* Created a `.yamlfix.toml` configuration file to align `yamlfix` settings with `yamllint` and ensure compatibility (`templates/lint/.yamlfix.toml`).

**Spell-checking configuration:**

* Added `yamlfix` to the list of allowed words in `.cspell.yaml` to prevent false positives during spell-checking (`templates/lint/.cspell.yaml`).