### PR TITLE
Minor correction to the fix.ps1 script, and documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Each CI/CD run progresses through the following stages:
 3. **Analyze** — CodeQL (produces SARIF output)
 4. **Validate** — Tool self-validation (produces TRX/JUnit output)
 5. **Document** — BuildMark · VersionMark · SonarMark · SarifMark · ReqStream (enforces requirements coverage) · ReviewMark (enforces file-review currency)
-6. **Publish** — Pandoc (Markdown→HTML) → Weasyprint (HTML→PDF)
+6. **Publish** — Pandoc (Markdown→HTML) → Weasyprint (HTML→PDF) → FileAssert (validates output documents)
 
 ### Tools
 
@@ -111,6 +111,7 @@ Each CI/CD run progresses through the following stages:
 | Build Notes | [BuildMark](https://github.com/demaconsulting/BuildMark) | Release change notes from Git history |
 | PDF Generation | [Pandoc](https://pandoc.org/) | Converts Markdown documents to HTML |
 | PDF Generation | [Weasyprint](https://weasyprint.org/) | Renders HTML to polished PDF documents |
+| File Assertions | [FileAssert](https://github.com/demaconsulting/FileAssert) | Validates pipeline outputs — file existence, size, text content, PDF metadata, XML, YAML, JSON, and HTML structure |
 
 ## Release Artifacts
 
@@ -183,6 +184,7 @@ Detailed documentation for each part of the pipeline:
 - [Self-Validation](docs/self-validation.md) — Tool self-validation as test evidence
 - [Build Notes Generation](docs/build-notes.md) — BuildMark configuration and output
 - [PDF Document Generation](docs/pdf-generation.md) — Pandoc and Weasyprint pipeline
+- [File Assertions](docs/file-assertions.md) — FileAssert configuration, acceptance criteria, OTS evidence, and PDF metadata validation
 - [AI Coding Agents](docs/agentic.md) — Structuring agent guidance files for Continuous Compliance
 - [Environment Setup](docs/environment-setup.md) — Setting up a local development environment
 - [Adopting Continuous Compliance](docs/migration.md) — Incremental migration guide for existing projects

--- a/docs/file-assertions.md
+++ b/docs/file-assertions.md
@@ -1,0 +1,268 @@
+# File Assertions
+
+[DemaConsulting.FileAssert](https://github.com/demaconsulting/FileAssert) is a .NET CLI tool for
+asserting file properties using YAML-defined test suites. It validates files against acceptance
+criteria such as existence, size, content, and structured document requirements — making it ideal
+for verifying CI/CD pipeline outputs.
+
+## Role in Continuous Compliance
+
+FileAssert fills two roles in the Continuous Compliance pipeline:
+
+1. **OTS Evidence** — assertions on outputs produced by third-party tools (Pandoc, WeasyPrint, or
+   any other tool) prove that those tools are functional in the target environment. These assertions
+   run *before* ReqStream generates the requirements documents, so the test results are available as
+   evidence when the trace matrix is assembled.
+
+2. **Output Validation** — assertions on all pipeline outputs (including the requirements and trace
+   matrix documents) confirm that each artifact was generated correctly, has the right content, and
+   meets structural requirements.
+
+## What FileAssert Can Check
+
+FileAssert supports a wide range of assertion types that apply to any file the pipeline produces:
+
+| File Type | What Can Be Checked |
+| :-------- | :------------------ |
+| **Any file** | Existence (count, min, max), size (min-size, max-size) |
+| **Text files** | Contains string, does not contain string, matches regex, does not match regex |
+| **PDF documents** | Metadata fields (Title, Author, Subject, Keywords), page count, body text |
+| **HTML documents** | XPath node queries with count, min, or max |
+| **XML documents** | XPath node queries with count, min, or max |
+| **YAML documents** | Dot-notation path queries with count, min, or max |
+| **JSON documents** | Dot-notation path queries with count, min, or max |
+
+This makes FileAssert applicable well beyond PDF validation — it can check build outputs,
+configuration artifacts, test result files, generated reports, and any other structured file
+the pipeline produces.
+
+## Configuration
+
+FileAssert reads a `.fileassert.yaml` file at the repository root. Tests are grouped using **tags**
+so they can be run in stages — for example, once per document group in the PDF pipeline:
+
+```yaml
+# .fileassert.yaml
+tests:
+
+  # --- File existence and size ---
+
+  - name: MyProject_ArtifactsExist
+    tags: [smoke]
+    files:
+      - pattern: "artifacts/*.nupkg"
+        count: 1
+        min-size: 1024
+
+  # --- Text file content ---
+
+  - name: MyProject_ChangelogValid
+    tags: [smoke]
+    files:
+      - pattern: "CHANGELOG.md"
+        count: 1
+        text:
+          - contains: "## "
+          - does-not-contain: "TODO"
+
+  # --- JSON config/artifact ---
+
+  - name: MyProject_VersionCaptureValid
+    tags: [smoke]
+    files:
+      - pattern: "artifacts/versionmark-*.json"
+        min: 1
+        json:
+          - query: "tools"
+            min: 1
+
+  # --- YAML config/artifact ---
+
+  - name: MyProject_RequirementsValid
+    tags: [smoke]
+    files:
+      - pattern: "requirements.yaml"
+        count: 1
+        yaml:
+          - query: "sections"
+            min: 1
+
+  # --- XML (e.g. TRX test results) ---
+
+  - name: MyProject_TestResultsValid
+    tags: [smoke]
+    files:
+      - pattern: "artifacts/*.trx"
+        min: 1
+        xml:
+          - query: "//*[local-name()='UnitTestResult']"
+            min: 1
+
+  # --- HTML (e.g. Pandoc intermediate output) ---
+
+  - name: Pandoc_UserGuideHtml
+    tags: [user-guide]
+    files:
+      - pattern: "docs/user_guide/user_guide.html"
+        count: 1
+        html:
+          - query: "//head/title"
+            count: 1
+        text:
+          - contains: "User Guide"
+
+  # --- PDF (e.g. WeasyPrint output) ---
+
+  - name: WeasyPrint_UserGuidePdf
+    tags: [user-guide]
+    files:
+      - pattern: "docs/MyProject User Guide.pdf"
+        count: 1
+        pdf:
+          metadata:
+            - field: "Title"
+              contains: "User Guide"
+            - field: "Author"
+              contains: "DEMA Consulting"
+            - field: "Subject"
+              contains: "User Guide"
+          pages:
+            min: 3
+          text:
+            - contains: "User Guide"
+```
+
+## Invocation
+
+FileAssert is invoked with a test name or tag to run only a targeted subset of tests. Pass
+`--results` to write a TRX or JUnit file that ReqStream can consume as test evidence:
+
+```bash
+# Run tests matching a tag
+dotnet fileassert --tag build-notes --results artifacts/fileassert-build-notes.trx
+
+# Run tests matching a name
+dotnet fileassert MyProject_ArtifactsExist --results artifacts/fileassert-smoke.trx
+
+# Run all tests
+dotnet fileassert --results artifacts/fileassert-all.trx
+```
+
+## Acceptance Criteria Reference
+
+| Criterion | Description |
+| :-------- | :---------- |
+| `count` | Exact number of files matching the glob pattern |
+| `min` | Minimum number of files matching the glob pattern |
+| `max` | Maximum number of files matching the glob pattern |
+| `min-size` | Minimum file size in bytes |
+| `max-size` | Maximum file size in bytes |
+| `text[].contains` | File text must contain the specified string |
+| `text[].does-not-contain` | File text must not contain the specified string |
+| `text[].matches` | File text must match the specified regular expression |
+| `text[].does-not-contain-regex` | File text must not match the specified regular expression |
+| `pdf.metadata[].field` + `contains` | PDF metadata field must contain the specified text |
+| `pdf.metadata[].field` + `matches` | PDF metadata field must match the regular expression |
+| `pdf.pages.min` / `pdf.pages.max` | PDF page count bounds |
+| `pdf.text[].contains` | PDF body text must contain the specified text |
+| `html[].query` + `count`/`min`/`max` | XPath node selection with count assertions |
+| `xml[].query` + `count`/`min`/`max` | XPath node selection with count assertions |
+| `yaml[].query` + `count`/`min`/`max` | Dot-notation path with count assertions |
+| `json[].query` + `count`/`min`/`max` | Dot-notation path with count assertions |
+
+## PDF Metadata Assertions
+
+When validating generated PDF documents, metadata fields map directly to the document's `title.txt`
+Pandoc front matter:
+
+| PDF Metadata Field | Source in `title.txt` | Example Assertion |
+| :----------------- | :-------------------- | :---------------- |
+| `Title` | `title:` | `contains: "MyProject User Guide"` |
+| `Author` | `author:` | `contains: "DEMA Consulting"` |
+| `Subject` | `description:` | `contains: "User Guide"` |
+| `Keywords` | `keywords:` list | `contains: "User Guide"` |
+
+> **Note:** The `subtitle:` field in `title.txt` appears only on the visual cover page — it does
+> **not** map to any PDF metadata field. All `Subject` assertions must match the `description:`
+> field.
+
+## OTS Evidence Timing
+
+In the PDF generation pipeline, FileAssert tests for each document group (build-notes, code-quality,
+code-review, design, user-guide) run *before* ReqStream generates the requirements and trace matrix
+documents. This is intentional: ReqStream consumes TRX files matching `artifacts/**/*.trx`, so the
+individual `fileassert-*.trx` result files are available as test evidence when ReqStream runs.
+
+Tests for the requirements documents themselves (tagged `requirements`) run *after* ReqStream
+completes. They validate those final documents are well-formed but do not contribute to OTS
+requirements evidence.
+
+## Self-Validation
+
+FileAssert includes built-in self-validation tests that verify its assertion engine is functional:
+
+```bash
+dotnet fileassert --validate --results artifacts/fileassert-self-validation.trx
+```
+
+Run self-validation after the document-group assertions and before ReqStream, so the result is
+available as evidence for FileAssert's own requirements.
+
+## CI/CD Integration
+
+A complete document-generation job interleaves FileAssert assertions with document production:
+
+```yaml
+# Generate and assert the Build Notes group
+- name: Generate Build Notes HTML with Pandoc
+  shell: bash
+  run: >
+    dotnet pandoc
+    --defaults docs/build_notes/definition.yaml
+    --metadata version="${{ inputs.version }}"
+    --output docs/build_notes/build_notes.html
+
+- name: Generate Build Notes PDF with WeasyPrint
+  shell: bash
+  run: >
+    dotnet weasyprint --pdf-variant pdf/a-3u
+    docs/build_notes/build_notes.html
+    "docs/MyProject Build Notes.pdf"
+
+- name: Assert Build Notes Documents with FileAssert
+  shell: bash
+  run: >
+    dotnet fileassert
+    --tag build-notes
+    --results artifacts/fileassert-build-notes.trx
+
+# ... repeat for code-quality, code-review, design, user-guide ...
+
+# FileAssert self-validation — after all OTS document groups are done
+- name: Run FileAssert self-validation
+  shell: bash
+  run: >
+    dotnet fileassert
+    --validate
+    --results artifacts/fileassert-self-validation.trx
+
+# Requirements and trace matrix — after all OTS evidence is in place
+- name: Run ReqStream
+  shell: bash
+  run: >
+    dotnet reqstream
+    --requirements requirements.yaml
+    --tests "artifacts/**/*.trx"
+    --enforce
+
+# Validate requirements documents — these run after ReqStream
+- name: Assert Requirements Documents with FileAssert
+  shell: bash
+  run: >
+    dotnet fileassert
+    --tag requirements
+    --results artifacts/fileassert-requirements.trx
+```
+
+See [PDF Document Generation](pdf-generation.md) for the full Pandoc and WeasyPrint pipeline that
+produces the documents FileAssert validates.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -106,6 +106,24 @@ archivable PDF/A-3u files. It depends on all upstream stages being in place.
 
 See [PDF Document Generation](pdf-generation.md) for the full pipeline.
 
+### Stage 7: File Assertions
+
+FileAssert validates that each generated HTML and PDF document is well-formed, contains expected
+content, and carries the correct metadata. Adding it after PDF generation completes the evidence
+chain — proving Pandoc and WeasyPrint are operational in your environment.
+
+- [ ] Install FileAssert: add it to `.config/dotnet-tools.json`
+- [ ] Create `.fileassert.yaml` at the repository root, defining one test per HTML file and one
+  test per PDF file, grouped by tag to match the document groups in your pipeline
+- [ ] Add `--tag` and `--results` assertions steps after each document group's Weasyprint step
+  in your CI/CD pipeline
+- [ ] Add a FileAssert self-validation step after all document groups and before ReqStream
+- [ ] Add a final `--tag requirements` assertions step after ReqStream completes
+- [ ] Confirm all assertions pass and the TRX result files are consumed by ReqStream
+
+See [File Assertions](file-assertions.md) for configuration details and the OTS evidence timing
+guidelines.
+
 ## Handling Existing Documentation
 
 Most projects accumulate documentation that pre-dates Continuous Compliance. The recommended approach:

--- a/docs/pdf-generation.md
+++ b/docs/pdf-generation.md
@@ -108,3 +108,25 @@ requirements documents have been generated:
 ```
 
 The resulting PDF files are uploaded as pipeline artifacts and attached to the GitHub Release.
+
+## Stage 3: Document Validation with FileAssert
+
+After each document group is generated, [DemaConsulting.FileAssert](https://github.com/demaconsulting/FileAssert)
+validates that the Pandoc HTML and WeasyPrint PDF outputs are well-formed and carry the expected
+metadata. Running FileAssert immediately after each document group — before moving to the next —
+means that by the time ReqStream generates the requirements documents, there is already a full set of
+passing test results proving Pandoc and WeasyPrint are operational.
+
+FileAssert can check any combination of file existence, size, text content, PDF metadata and page
+counts, and structured document content (HTML, XML, YAML, JSON). For the PDF generation pipeline
+the most common assertions are HTML structure and PDF metadata:
+
+```bash
+dotnet fileassert \
+  --tag build-notes \
+  --results artifacts/fileassert-build-notes.trx
+```
+
+FileAssert checks are defined in `.fileassert.yaml` at the repository root, grouped by tag to match
+the document groups in the pipeline. See [File Assertions](file-assertions.md) for the full
+configuration reference.

--- a/docs/self-validation.md
+++ b/docs/self-validation.md
@@ -24,6 +24,7 @@ themselves validated using the same Continuous Compliance infrastructure.
 | [ReqStream](https://github.com/demaconsulting/ReqStream) | `dotnet reqstream --validate --results results.trx` |
 | [ReviewMark](https://github.com/demaconsulting/ReviewMark) | `dotnet reviewmark --validate --results results.trx` |
 | [BuildMark](https://github.com/demaconsulting/BuildMark) | `dotnet buildmark --validate --results results.trx` |
+| [FileAssert](https://github.com/demaconsulting/FileAssert) | `dotnet fileassert --validate --results results.trx` |
 
 ## CI/CD Integration
 
@@ -74,6 +75,9 @@ tools' own requirements:
 
 - name: Run SonarMark self-validation
   run: dotnet sonarmark --validate --results artifacts/sonarmark-self-validation.trx
+
+- name: Run FileAssert self-validation
+  run: dotnet fileassert --validate --results artifacts/fileassert-self-validation.trx
 ```
 
 ## Self-Validation Output

--- a/templates/lint/fix.ps1
+++ b/templates/lint/fix.ps1
@@ -35,7 +35,6 @@ function Initialize-PythonVenv {
     $activateScript = Get-VenvActivateScript
     if (-not $activateScript) { return $false }
     if ($Silent) { & $activateScript 2>$null } else { & $activateScript }
-    if ($LASTEXITCODE -ne 0) { return $false }
     if (-not (Get-Command deactivate -ErrorAction SilentlyContinue)) { return $false }
 
     $installSucceeded = $false


### PR DESCRIPTION
This pull request introduces comprehensive documentation and integration for FileAssert, a tool for validating CI/CD pipeline outputs. The changes add FileAssert as a required stage in the pipeline, document its configuration and usage, and update related guides to reflect its role in ensuring output files are correct and provide evidence for compliance.

**FileAssert Integration and Documentation:**

* Added a new section to the pipeline documenting the "Publish" stage now includes FileAssert to validate output documents (`README.md`).
* Introduced FileAssert to the list of pipeline tools, describing its capabilities and linking to its repository (`README.md`).
* Added a detailed documentation page for FileAssert, covering configuration, supported assertions, invocation, acceptance criteria, PDF metadata validation, OTS evidence timing, self-validation, and CI/CD integration (`docs/file-assertions.md`).
* Updated the migration guide to include FileAssert as Stage 7, with checklist steps for adoption and integration into the pipeline (`docs/migration.md`).
* Updated the PDF generation documentation to describe how FileAssert validates HTML and PDF outputs after each document group is generated (`docs/pdf-generation.md`).
* Added FileAssert to the self-validation documentation, including invocation examples and CI/CD integration steps (`docs/self-validation.md`). [[1]](diffhunk://#diff-d8decc45f95815f5a5f8b090266280d9fd76bb1f9cbe7e6d6cdf1a34564a1f5cR27) [[2]](diffhunk://#diff-d8decc45f95815f5a5f8b090266280d9fd76bb1f9cbe7e6d6cdf1a34564a1f5cR78-R80)

**Other Minor Changes:**

* Removed an unnecessary check for `$LASTEXITCODE` in the PowerShell script `fix.ps1` (`templates/lint/fix.ps1`).